### PR TITLE
Avalonia 12.0.3 Bump + Live Theme Updates + Cover/Icon Memory Fixes + Price Analysis Stability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,13 +4,13 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup Label="Avalonia">
-    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Controls.ColorPicker" Version="12.0.3" />
     <PackageVersion Include="Avalonia.Controls.ItemsRepeater" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.15" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.3" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
-    <PackageVersion Include="Avalonia.Headless.NUnit" Version="12.0.1" />
+    <PackageVersion Include="Avalonia.Headless.NUnit" Version="12.0.3" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.1" />
     <PackageVersion Include="ReactiveUI.SourceGenerators" Version="2.6.30" />
   </ItemGroup>
@@ -21,25 +21,25 @@
     <PackageVersion Include="GraphQL.Client" Version="6.1.0" />
     <PackageVersion Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
     <PackageVersion Include="MangaAndLightNovelWebScrape" Version="5.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageVersion Include="NLog" Version="6.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageVersion Include="NLog" Version="6.1.3" />
     <PackageVersion Include="D2Phap.FileWatcherEx" Version="3.0.0" />
     <PackageVersion Include="Optris.Icons.Avalonia.FontAwesome7" Version="12.0.6" />
     <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.7.2" />
-    <PackageVersion Include="System.Drawing.Common" Version="10.0.7" />
+    <PackageVersion Include="System.Drawing.Common" Version="10.0.8" />
     <PackageVersion Include="TextCopy" Version="6.2.1" />
     <PackageVersion Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-292" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="ZLinq" Version="1.5.6" />
   </ItemGroup>
   <ItemGroup Label="Testing">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="NUnit" Version="4.6.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
   </ItemGroup>
   <ItemGroup Label="Packaging">
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1721" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.1839" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />

--- a/Src/Assets/changelog.json
+++ b/Src/Assets/changelog.json
@@ -104,5 +104,17 @@
     "actions": [
       "Open Edit Series for any item whose Total Value was entered in a non-USD currency on 2.2.0 — the value now displays in the currency's natural format and may differ from what you saw before"
     ]
+  },
+  "2.2.2": {
+    "changes": [
+      "Card Border color in the theme picker now updates live as you change it — previously the new color only appeared after restarting or switching themes",
+      "Pasting a long cover image URL into Edit Series no longer stretches the window — the textbox stays at its normal width and scrolls horizontally",
+      "Color picker swatches now have a small inset between the border ring and the color itself for a cleaner look",
+      "Price Analysis no longer crashes when the website selection is bulk-cleared or reordered",
+      "User icon picker decodes at the target display size instead of loading the full source image — uses far less memory for high-resolution icons",
+      "Theme picker live preview is smoother — fewer allocations while dragging color values",
+      "Upgraded Avalonia UI framework to 12.0.3 for upstream rendering fixes and stability improvements"
+    ],
+    "actions": []
   }
 }

--- a/Src/Controls/ColorPickerItem.axaml
+++ b/Src/Controls/ColorPickerItem.axaml
@@ -18,13 +18,17 @@
             Margin="3"
             MinWidth="180">
         <StackPanel Orientation="Horizontal" Spacing="8">
-            <Button Background="{CompiledBinding ColorBrush, ElementName=Root}"
+            <Button Background="Transparent"
                     Width="28" Height="28"
                     CornerRadius="6"
                     BorderBrush="{DynamicResource TsundokuDividerColor}"
                     BorderThickness="2"
-                    Padding="0"
+                    Padding="3"
                     Cursor="Hand">
+                <Border Background="{CompiledBinding ColorBrush, ElementName=Root}"
+                        CornerRadius="3"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"/>
                 <Button.Flyout>
                     <Flyout Placement="Bottom">
                         <ColorView Color="{CompiledBinding ColorBrush, ElementName=Root, Converter={StaticResource BrushToColorConverter}, Mode=TwoWay}"/>

--- a/Src/Controls/SeriesCardDisplay.axaml
+++ b/Src/Controls/SeriesCardDisplay.axaml
@@ -55,9 +55,6 @@
             Height="{CompiledBinding Source={x:Static m:Constants.CARD_HEIGHT}}"
             UseLayoutRounding="True"
             Classes="card-hover">
-          <Border.CacheMode>
-            <BitmapCache/>
-          </Border.CacheMode>
           <Border.Styles>
             <Style Selector="Border.card-hover">
               <Setter Property="RenderTransform" Value="translate(0px, 0px)"/>
@@ -73,6 +70,9 @@
           </Border.Transitions>
 
           <Border CornerRadius="14" ClipToBounds="True" Name="CardInner">
+            <Border.CacheMode>
+              <BitmapCache/>
+            </Border.CacheMode>
             <Grid ColumnDefinitions="Auto,*">
 
               <!-- ── Hover + ToolTip Styles ── -->

--- a/Src/Controls/SeriesCardDisplay.axaml.cs
+++ b/Src/Controls/SeriesCardDisplay.axaml.cs
@@ -45,6 +45,9 @@ public sealed partial class SeriesCardDisplay : UserControl
         set => SetValue(GlassEnabledProperty, value);
     }
 
+    private static MainWindowViewModel? _cachedMainWindowViewModel;
+    private static IUserService? _cachedUserService;
+
     private readonly MainWindowViewModel _mainWindowViewModel;
     private readonly IUserService _userService;
     private Guid _loadedCoverSeriesId;
@@ -52,11 +55,8 @@ public sealed partial class SeriesCardDisplay : UserControl
 
     public SeriesCardDisplay()
         : this(
-            App.ServiceProvider.GetRequiredService<MainWindowViewModel>()
-                ?? throw new InvalidOperationException("MainWindowViewModel not registered in DI container."),
-            App.ServiceProvider.GetRequiredService<IUserService>()
-                ?? throw new InvalidOperationException("IUserService not registered in DI container.")
-          )
+            _cachedMainWindowViewModel ??= App.ServiceProvider.GetRequiredService<MainWindowViewModel>(),
+            _cachedUserService ??= App.ServiceProvider.GetRequiredService<IUserService>())
     {
     }
 

--- a/Src/Converters/UserIconBitmapJsonConveter.cs
+++ b/Src/Converters/UserIconBitmapJsonConveter.cs
@@ -19,28 +19,8 @@ public sealed class UserIconBitmapJsonConverter : JsonConverter<Bitmap>
         try
         {
             byte[] imageBytes = Convert.FromBase64String(base64String);
-
-            // 1. Convert bytes to the original (unscaled) Bitmap
-            Bitmap? originalBitmap = BitmapConverter.BytesToBitmap(imageBytes);
-
-            if (originalBitmap is null)
-            {
-                LOGGER.Error("Failed to create original Bitmap from byte array.");
-                return null;
-            }
-
-            // 2. Apply the scaling
-            // Ensure PixelSize and BitmapInterpolationMode are accessible
-            Bitmap? scaledBitmap = originalBitmap.CreateScaledBitmap(
-                new PixelSize(USER_ICON_WIDTH * BITMAP_SCALE, USER_ICON_HEIGHT * BITMAP_SCALE),
-                BitmapInterpolationMode.HighQuality
-            );
-
-            // Dispose of the original bitmap if it's no longer needed
-            // This is important for memory management, especially if the original is large.
-            originalBitmap.Dispose();
-
-            return scaledBitmap;
+            using MemoryStream stream = new(imageBytes, writable: false);
+            return Bitmap.DecodeToWidth(stream, USER_ICON_WIDTH * BITMAP_SCALE, BitmapInterpolationMode.HighQuality);
         }
         catch (FormatException ex)
         {

--- a/Src/Helpers/BitmapHelper.cs
+++ b/Src/Helpers/BitmapHelper.cs
@@ -9,7 +9,7 @@ namespace Tsundoku.Helpers;
 public sealed class BitmapHelper
 {
     private static readonly Logger LOGGER = LogManager.GetCurrentClassLogger();
-    private static readonly RecyclableMemoryStreamManager StreamManager = new();
+    internal static readonly RecyclableMemoryStreamManager StreamManager = new();
     private readonly IHttpClientFactory _httpClientFactory;
 
     /// <summary>

--- a/Src/Helpers/ExtensionMethods.cs
+++ b/Src/Helpers/ExtensionMethods.cs
@@ -1,4 +1,6 @@
+using System.Buffers;
 using Avalonia.Media.Imaging;
+using Microsoft.IO;
 
 namespace Tsundoku.Helpers;
 
@@ -7,8 +9,19 @@ namespace Tsundoku.Helpers;
 /// </summary>
 public static class ExtensionMethods
 {
+    private static readonly SearchValues<char> SmartQuoteChars = SearchValues.Create(
+    [
+        '\u201C', '\u201D', '\u201E', '\u201F',
+        '\u2018', '\u2019', '\u201A', '\u201B',
+    ]);
+
+    private static readonly SearchValues<char> WhitespaceChars = SearchValues.Create(
+    [
+        '\u0020', '\u00A0', '\u1680', '\u2000', '\u2001', '\u2002', '\u2003', '\u2004', '\u2005', '\u2006', '\u2007', '\u2008', '\u2009', '\u200A', '\u202F', '\u205F', '\u3000', '\u2028', '\u2029', '\u0009', '\u000A', '\u000B', '\u000C', '\u000D', '\u0085',
+    ]);
+
     /// <summary>
-    /// Replaces all common “smart” double‐quotes and single‐quotes with
+    /// Replaces all common smart double-quotes and single-quotes with
     /// plain ASCII " and ' in one pass over the input.
     /// </summary>
     public static string NormalizeQuotes(this string input)
@@ -16,43 +29,20 @@ public static class ExtensionMethods
         if (string.IsNullOrEmpty(input))
             return input;
 
-        // Quick check: if there are no known smart‐quote codepoints, skip allocation
-        if (input.IndexOfAny(new char[]
-        {
-            '\u201C','\u201D','\u201E','\u201F',  // “ ” „ ‟
-            '\u2018','\u2019','\u201A','\u201B'   // ‘ ’ ‚ ‛
-        }) < 0)
+        if (input.AsSpan().IndexOfAny(SmartQuoteChars) < 0)
             return input;
 
         return string.Create(input.Length, input, (span, src) =>
         {
             for (int i = 0; i < src.Length; i++)
             {
-                // grab the char once
                 char c = src[i];
-                switch (c)
+                span[i] = c switch
                 {
-                    // double‐quotes → ASCII "
-                    case '\u201C': // left double quotation mark
-                    case '\u201D': // right double quotation mark
-                    case '\u201E': // double low-9 quotation mark
-                    case '\u201F': // double high-reversed-9 quotation mark
-                        span[i] = '"';
-                        break;
-
-                    // single‐quotes/apostrophes → ASCII '
-                    case '\u2018': // left single quotation mark
-                    case '\u2019': // right single quotation mark
-                    case '\u201A': // single low-9 quotation mark
-                    case '\u201B': // single high-reversed-9 quotation mark
-                        span[i] = '\'';
-                        break;
-
-                    // all others stay the same
-                    default:
-                        span[i] = c;
-                        break;
-                }
+                    '\u201C' or '\u201D' or '\u201E' or '\u201F' => '"',
+                    '\u2018' or '\u2019' or '\u201A' or '\u201B' => '\'',
+                    _ => c,
+                };
             }
         });
     }
@@ -68,12 +58,12 @@ public static class ExtensionMethods
             return null;
         }
 
-        using MemoryStream ms = new MemoryStream();
-        source.Save(ms);           // Encode to PNG (in-memory)
-        ms.Position = 0;           // Rewind before reading
-        return new Bitmap(ms);     // Decode into new Bitmap
+        using RecyclableMemoryStream stream = BitmapHelper.StreamManager.GetStream(nameof(CloneBitmap));
+        source.Save(stream);
+        stream.Position = 0;
+        return new Bitmap(stream);
     }
-    
+
     /// <summary>
     /// Computes the Levenshtein edit distance between two strings, returning -1 if it exceeds the maximum allowed distance.
     /// </summary>
@@ -183,50 +173,31 @@ public static class ExtensionMethods
     /// <returns>A new string with all whitespace characters removed.</returns>
     public static string RemoveInPlaceCharArray(string input)
     {
-        int len = input.Length;
-        char[] src = input.ToCharArray();
+        if (string.IsNullOrEmpty(input)) return input;
+
+        ReadOnlySpan<char> src = input;
+        if (src.IndexOfAny(WhitespaceChars) < 0) return input;
+
+        const int StackThreshold = 512;
+        char[]? rented = src.Length > StackThreshold ? ArrayPool<char>.Shared.Rent(src.Length) : null;
+        Span<char> dst = rented is not null ? rented.AsSpan(0, src.Length) : stackalloc char[src.Length];
+
         int dstIdx = 0;
-        for (int i = 0; i < len; i++)
+        foreach (char ch in src)
         {
-            char ch = src[i];
-            switch (ch)
+            if (!WhitespaceChars.Contains(ch))
             {
-                case '\u0020':
-                case '\u00A0':
-                case '\u1680':
-                case '\u2000':
-                case '\u2001':
-                case '\u2002':
-                case '\u2003':
-                case '\u2004':
-                case '\u2005':
-                case '\u2006':
-                case '\u2007':
-                case '\u2008':
-                case '\u2009':
-                case '\u200A':
-                case '\u202F':
-                case '\u205F':
-                case '\u3000':
-                case '\u2028':
-                case '\u2029':
-                case '\u0009':
-                case '\u000A':
-                case '\u000B':
-                case '\u000C':
-                case '\u000D':
-                case '\u0085':
-                    continue;
-                default:
-                    src[dstIdx++] = ch;
-                    break;
+                dst[dstIdx++] = ch;
             }
         }
-        return new string(src, 0, dstIdx);
+
+        string result = new(dst[..dstIdx]);
+        if (rented is not null) ArrayPool<char>.Shared.Return(rented);
+        return result;
     }
 
     /// <summary>
-    /// Returns true if both dictionaries are null, or both non-null with identical key sets 
+    /// Returns true if both dictionaries are null, or both non-null with identical key sets
     /// and equal values for each key.
     /// </summary>
     public static bool DictionariesEqual<TKey, TValue>(

--- a/Src/Models/Series.cs
+++ b/Src/Models/Series.cs
@@ -923,7 +923,8 @@ public sealed partial class Series(
                 {
                     try
                     {
-                        newCover = new Bitmap(fullPath);
+                        using FileStream coverStream = new(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, options: FileOptions.SequentialScan);
+                        newCover = Bitmap.DecodeToWidth(coverStream, LEFT_SIDE_CARD_WIDTH * BITMAP_SCALE, BitmapInterpolationMode.HighQuality);
                     }
                     catch (Exception ex)
                     {

--- a/Src/Services/DiscordRP.cs
+++ b/Src/Services/DiscordRP.cs
@@ -26,9 +26,16 @@ internal sealed class FilteredDiscordLogger : DiscordRPC.Logging.ILogger
 public static class DiscordRP
 {
     private static readonly Logger LOGGER = LogManager.GetCurrentClassLogger();
+    private static readonly Assets _staticAssets = new()
+    {
+        LargeImageKey = "rp_large_icon",
+        LargeImageText = "Tsundoku"
+    };
     private static DiscordRpcClient? client;
     private static string UserName = string.Empty;
     private static PresenceState _presence = new();
+    private static Button[]? _cachedButtons;
+    private static bool _buttonsDirty = true;
 
     public static void Initialize()
     {
@@ -110,11 +117,13 @@ public static class DiscordRP
         if (_presence.Buttons.Count > 1)
         {
             _presence.Buttons.RemoveRange(1, _presence.Buttons.Count - 1);
+            _buttonsDirty = true;
         }
         if (additionalButton is not null)
         {
             LOGGER.Debug("Adding additional button");
             _presence.Buttons.Add(additionalButton);
+            _buttonsDirty = true;
         }
 
         ResetPresence();
@@ -127,17 +136,19 @@ public static class DiscordRP
             return;
         }
 
+        if (_buttonsDirty || _cachedButtons is null)
+        {
+            _cachedButtons = [.. _presence.Buttons];
+            _buttonsDirty = false;
+        }
+
         client.SetPresence(new RichPresence
         {
             Details = _presence.Details,
             State = _presence.State,
             Timestamps = _presence.Timestamps,
-            Buttons = [.. _presence.Buttons],
-            Assets = new Assets
-            {
-                LargeImageKey = "rp_large_icon",
-                LargeImageText = "Tsundoku"
-            }
+            Buttons = _cachedButtons,
+            Assets = _staticAssets
         });
     }
 
@@ -148,6 +159,7 @@ public static class DiscordRP
             return;
         }
         _presence = new PresenceState();
+        _buttonsDirty = true;
         ResetPresence();
     }
 

--- a/Src/Services/GlassmorphismService.cs
+++ b/Src/Services/GlassmorphismService.cs
@@ -107,6 +107,12 @@ public static class GlassmorphismService
         LOGGER.Info("Glassmorphism {State}", enabled ? "enabled" : "disabled");
     }
 
+    private static readonly IReadOnlyList<WindowTransparencyLevel> GlassLevels =
+        [WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Blur];
+
+    private static readonly IReadOnlyList<WindowTransparencyLevel> NoGlassLevels =
+        [WindowTransparencyLevel.None];
+
     /// <summary>
     /// Applies glassmorphism transparency settings to a single window.
     /// Also forces named controls to pick up the new resource values.
@@ -115,12 +121,12 @@ public static class GlassmorphismService
     {
         if (enabled)
         {
-            window.TransparencyLevelHint = [WindowTransparencyLevel.AcrylicBlur, WindowTransparencyLevel.Blur];
+            window.TransparencyLevelHint = GlassLevels;
             window.Background = Brushes.Transparent;
         }
         else
         {
-            window.TransparencyLevelHint = [WindowTransparencyLevel.None];
+            window.TransparencyLevelHint = NoGlassLevels;
             window.Background = null;
         }
 

--- a/Src/Services/UserService.cs
+++ b/Src/Services/UserService.cs
@@ -278,8 +278,8 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
         }
 
         User loadedUser;
-        string userFileData = await File.ReadAllTextAsync(userDataFilePath);
-        if (string.IsNullOrWhiteSpace(userFileData))
+        FileInfo fileInfo = new(userDataFilePath);
+        if (fileInfo.Length == 0)
         {
             LOGGER.Debug("Json is Empty Creating Default User");
             loadedUser = CreateDefaultUser();
@@ -288,7 +288,12 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
         {
             try
             {
-                JsonNode? userData = JsonNode.Parse(userFileData);
+                JsonNode? userData;
+                await using (FileStream stream = new(userDataFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, options: FileOptions.Asynchronous | FileOptions.SequentialScan))
+                {
+                    userData = await JsonNode.ParseAsync(stream);
+                }
+
                 if (userData is not null)
                 {
                     User.UpdateSchemaVersion(userData, false);
@@ -334,8 +339,12 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
 
         try
         {
-            string userFileData = await File.ReadAllTextAsync(userDataFilePath);
-            JsonNode? userData = JsonNode.Parse(userFileData);
+            JsonNode? userData;
+            await using (FileStream stream = new(userDataFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, options: FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                userData = await JsonNode.ParseAsync(stream);
+            }
+
             if (userData is null)
             {
                 LOGGER.Warn("UserData.json is malformed, cannot repair");
@@ -360,16 +369,15 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
     {
         string currentName = GetCurrentThemeSnapshot().ThemeName;
 
-        // This only loops until it finds the first match (or until the end).
-        var match = _savedThemes
-            .AsValueEnumerable()
-            .Select((theme, idx) => new { theme, idx })
-            .FirstOrDefault(x => x.theme.ThemeName.Equals(currentName));
+        for (int i = 0; i < _savedThemes.Count; i++)
+        {
+            if (_savedThemes[i].ThemeName.Equals(currentName, StringComparison.Ordinal))
+            {
+                return (uint)i;
+            }
+        }
 
-        // If no match, FirstOrDefault returns null, so idx = 0 by default.
-        int foundIndex = (match is null) ? -1 : match.idx;
-
-        return (uint)(foundIndex >= 0 ? foundIndex : 0);
+        return 0;
     }
 
 
@@ -472,31 +480,17 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
 
     private static Bitmap GenerateCoverBitmap(Series series, string fullCoverPath, bool isPngExtension)
     {
-        Bitmap loadedBitmap = new(fullCoverPath);
-        if (!isPngExtension)
-        {
-            fullCoverPath = Path.ChangeExtension(fullCoverPath, ".png");
-        }
-
         int targetWidth = LEFT_SIDE_CARD_WIDTH * BITMAP_SCALE;
-        int targetHeight = IMAGE_HEIGHT * BITMAP_SCALE;
-        if (loadedBitmap.PixelSize.Width > targetWidth || loadedBitmap.PixelSize.Height > targetHeight)
+        using FileStream sourceStream = new(fullCoverPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, options: FileOptions.SequentialScan);
+        Bitmap decoded = Bitmap.DecodeToWidth(sourceStream, targetWidth, BitmapInterpolationMode.HighQuality);
+
+        string savePath = isPngExtension ? fullCoverPath : Path.ChangeExtension(fullCoverPath, ".png");
+        if (!isPngExtension || decoded.PixelSize.Width != targetWidth)
         {
-            Bitmap scaledBitmap = loadedBitmap.CreateScaledBitmap(new PixelSize(targetWidth, targetHeight), BitmapInterpolationMode.HighQuality);
-            LOGGER.Debug("Scaled {Title} cover to {Width}x{Height}", series.Titles[TsundokuLanguage.Romaji], targetWidth, targetHeight);
-            loadedBitmap.Dispose();
-
-            scaledBitmap.Save(fullCoverPath, 100);
-            return scaledBitmap;
+            decoded.Save(savePath, 100);
+            LOGGER.Debug("Saved {Title} cover at {Width}px to {Path}", series.Titles[TsundokuLanguage.Romaji], decoded.PixelSize.Width, savePath);
         }
-
-        if (!isPngExtension)
-        {
-            loadedBitmap.Save(fullCoverPath, 100);
-            LOGGER.Info("Saved Cover {path}", fullCoverPath);
-        }
-
-        return loadedBitmap;
+        return decoded;
     }
 
     public Series? GetSeriesByCoverPath(string coverPath)
@@ -553,8 +547,11 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
     {
         try
         {
-            string fileText = await File.ReadAllTextAsync(filePath);
-            JsonNode? uploadedUserData = await Task.Run(() => JsonNode.Parse(fileText));
+            JsonNode? uploadedUserData;
+            await using (FileStream stream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, options: FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                uploadedUserData = await JsonNode.ParseAsync(stream);
+            }
 
             if (uploadedUserData is null)
             {
@@ -1178,8 +1175,8 @@ public sealed partial class UserService : ReactiveObject, IUserService, IDisposa
             return;
         }
         
-        using Bitmap originalIcon = new Bitmap(filePath);
-        Bitmap scaledIcon = originalIcon.CreateScaledBitmap(new PixelSize(USER_ICON_WIDTH * BITMAP_SCALE, USER_ICON_HEIGHT * BITMAP_SCALE), BitmapInterpolationMode.HighQuality);
+        using FileStream iconStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, options: FileOptions.SequentialScan);
+        Bitmap scaledIcon = Bitmap.DecodeToWidth(iconStream, USER_ICON_WIDTH * BITMAP_SCALE, BitmapInterpolationMode.HighQuality);
         currentUser.UserIcon?.Dispose();
         currentUser.UserIcon = scaledIcon;
 

--- a/Src/ViewModels/CollectionStatsViewModel.cs
+++ b/Src/ViewModels/CollectionStatsViewModel.cs
@@ -735,6 +735,16 @@ public sealed partial class CollectionStatsViewModel : ViewModelBase, IDisposabl
         };
     }
 
+    private static string[] ExtractKeys(KeyValuePair<string, int>[] source)
+    {
+        string[] result = new string[source.Length];
+        for (int i = 0; i < source.Length; i++)
+        {
+            result[i] = source[i].Key;
+        }
+        return result;
+    }
+
     private void UpdateSplitGenreCharts(KeyValuePair<string, int>[] orderedGenreData)
     {
         int midpoint = (orderedGenreData.Length + 1) / 2;
@@ -747,7 +757,7 @@ public sealed partial class CollectionStatsViewModel : ViewModelBase, IDisposabl
         }
         if (GenreYAxes1 is { Length: > 0 })
         {
-            GenreYAxes1[0].Labels = firstHalf.AsValueEnumerable().Select(kvp => kvp.Key).ToArray();
+            GenreYAxes1[0].Labels = ExtractKeys(firstHalf);
         }
 
         if (GenreDistribution2.Count > 0 && GenreDistribution2[0] is RowSeries<KeyValuePair<string, int>> series2)
@@ -756,7 +766,7 @@ public sealed partial class CollectionStatsViewModel : ViewModelBase, IDisposabl
         }
         if (GenreYAxes2 is { Length: > 0 })
         {
-            GenreYAxes2[0].Labels = secondHalf.AsValueEnumerable().Select(kvp => kvp.Key).ToArray();
+            GenreYAxes2[0].Labels = ExtractKeys(secondHalf);
         }
     }
 
@@ -852,7 +862,7 @@ public sealed partial class CollectionStatsViewModel : ViewModelBase, IDisposabl
 
                 if (GenreYAxes is { Length: > 0 })
                 {
-                    GenreYAxes[0].Labels = calculatedGenreData.AsValueEnumerable().Select(kvp => kvp.Key).ToArray();
+                    GenreYAxes[0].Labels = ExtractKeys(calculatedGenreData);
                 }
 
                 UpdateSplitGenreCharts(calculatedGenreData);

--- a/Src/ViewModels/FilterChipViewModel.cs
+++ b/Src/ViewModels/FilterChipViewModel.cs
@@ -24,10 +24,10 @@ public sealed partial class FilterChipViewModel : ReactiveObject
     private static readonly FrozenDictionary<string, string[]> EnumValues =
         new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
         {
-            ["Format"] = Enum.GetValues<SeriesFormat>().Select(e => e.ToString()).ToArray(),
-            ["Status"] = Enum.GetValues<SeriesStatus>().Select(e => e.ToString()).ToArray(),
-            ["Demographic"] = Enum.GetValues<SeriesDemographic>().Select(e => e.ToString()).ToArray(),
-            ["Genre"] = Enum.GetValues<SeriesGenre>().Select(e => e.ToString()).ToArray(),
+            ["Format"] = Enum.GetNames<SeriesFormat>(),
+            ["Status"] = Enum.GetNames<SeriesStatus>(),
+            ["Demographic"] = Enum.GetNames<SeriesDemographic>(),
+            ["Genre"] = Enum.GetNames<SeriesGenre>(),
             ["Series"] = ["Complete", "InComplete"],
             ["Favorite"] = ["True", "False"],
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);

--- a/Src/ViewModels/PriceAnalysisViewModel.cs
+++ b/Src/ViewModels/PriceAnalysisViewModel.cs
@@ -22,7 +22,7 @@ public sealed partial class PriceAnalysisViewModel : ViewModelBase, IDisposable
     [Reactive] public partial string WebsitesToolTipText { get; set; }
     [Reactive] public partial int CurRegionIndex { get; set; }
     public AvaloniaList<ListBoxItem> SelectedWebsites { get; } = [];
-    private static readonly StringBuilder CurWebsites = new();
+    private readonly StringBuilder _curWebsites = new();
     private static readonly Region[] CachedRegionValues = Enum.GetValues<Region>();
 
     public static readonly FrozenSet<string> ANALYSIS_COUNTRY_OPTIONS = new[]
@@ -67,30 +67,19 @@ public sealed partial class PriceAnalysisViewModel : ViewModelBase, IDisposable
 
     private void WebsiteCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        switch (e.Action)
+        if (SelectedWebsites is null || SelectedWebsites.Count == 0)
         {
-            case NotifyCollectionChangedAction.Add:
-            case NotifyCollectionChangedAction.Remove:
-                if (SelectedWebsites is not null && SelectedWebsites.Count != 0)
-                {
-                    for (int x = 0; x < SelectedWebsites.Count - 1; x++)
-                    {
-                        CurWebsites.AppendLine(SelectedWebsites[x].Content.ToString());
-                    }
-                    CurWebsites.Append(SelectedWebsites.Last().Content.ToString());
-                    WebsitesToolTipText = CurWebsites.ToString();
-                    CurWebsites.Clear();
-                }
-                else
-                {
-                    CurWebsites.Clear();
-                    WebsitesToolTipText = CurWebsites.ToString();
-                }
-                return;
-            default:
-                throw new ArgumentOutOfRangeException();
+            WebsitesToolTipText = string.Empty;
+            return;
         }
 
+        for (int x = 0; x < SelectedWebsites.Count - 1; x++)
+        {
+            _curWebsites.AppendLine(SelectedWebsites[x].Content.ToString());
+        }
+        _curWebsites.Append(SelectedWebsites[^1].Content.ToString());
+        WebsitesToolTipText = _curWebsites.ToString();
+        _curWebsites.Clear();
     }
 
     public void Dispose()

--- a/Src/Views/ChangelogWindow.axaml.cs
+++ b/Src/Views/ChangelogWindow.axaml.cs
@@ -1,5 +1,10 @@
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using System.Reactive.Linq;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
+using ReactiveUI;
 using ReactiveUI.Avalonia;
 using Tsundoku.Models;
 using Tsundoku.ViewModels;
@@ -15,9 +20,14 @@ public sealed partial class ChangelogWindow : ReactiveWindow<ViewModelBase>
     {
         InitializeComponent();
 
-        ChangesScroll.GetObservable(ScrollViewer.ExtentProperty).Subscribe(_ => UpdateScrollHint());
-        ChangesScroll.GetObservable(ScrollViewer.ViewportProperty).Subscribe(_ => UpdateScrollHint());
-        ChangesScroll.GetObservable(ScrollViewer.OffsetProperty).Subscribe(_ => UpdateScrollHint());
+        this.WhenActivated(disposables =>
+        {
+            ChangesScroll.GetObservable(ScrollViewer.ExtentProperty).Select(_ => Unit.Default)
+                .Merge(ChangesScroll.GetObservable(ScrollViewer.ViewportProperty).Select(_ => Unit.Default))
+                .Merge(ChangesScroll.GetObservable(ScrollViewer.OffsetProperty).Select(_ => Unit.Default))
+                .Subscribe(_ => UpdateScrollHint())
+                .DisposeWith(disposables);
+        });
 
         _sortedVersions = Changelog.Entries.Keys
             .OrderBy(v => Version.TryParse(v, out Version? parsed) ? parsed : new Version(0, 0))

--- a/Src/Views/EditSeriesInfoWindow.axaml
+++ b/Src/Views/EditSeriesInfoWindow.axaml
@@ -108,7 +108,7 @@
                     <StackPanel Spacing="4">
                         <TextBlock Text="COVER IMAGE URL" Classes="section-title"
                                    ToolTip.Tip="{CompiledBinding CoverImageUrl}"/>
-                        <Grid ColumnDefinitions="*,6,Auto,6,Auto">
+                        <Grid ColumnDefinitions="*,6,Auto,6,Auto" Width="460">
                             <TextBox x:Name="CoverImageUrlTextBox"
                                      Grid.Column="0"
                                      FontSize="13" Height="34"


### PR DESCRIPTION
﻿## Summary
Brings the v2.2.2 release work to `main`: upgrades the Avalonia UI framework (and several supporting packages), fixes a handful of theme-picker and Edit Series UX papercuts, makes Price Analysis robust against bulk website list changes, and cuts memory usage on cover/icon loading by decoding images straight to their display size. Also includes small allocation cleanups across hot paths in extensions, view models, and Discord rich presence updates.

## Changes

### UI fixes
- Theme picker's Card Border color now updates live as the value changes instead of requiring a theme switch or restart — the swatch button paints a transparent host with an inner `Border` so the color binding re-renders immediately, and a small inset sits between the ring and the swatch for a cleaner look.
- Edit Series no longer stretches horizontally when a long cover image URL is pasted — the URL row is pinned to a fixed `460` width so the text box scrolls instead of growing.
- Changelog window's scroll-hint subscriptions are now disposed with `WhenActivated`, preventing leaks when the window is reopened.

### Stability
- Price Analysis no longer throws `ArgumentOutOfRangeException` when the selected-websites list is bulk-cleared, `Reset`, or otherwise reordered — the collection-changed handler now treats any non-Add/Remove action uniformly and short-circuits cleanly on empty selections. `CurWebsites` is also instance-scoped now, so it can't bleed across view-model lifetimes.

### Memory / performance
- User icon JSON converter decodes directly to the target display size via `Bitmap.DecodeToWidth` instead of allocating a full-resolution bitmap and rescaling — far less memory for high-resolution source icons.
- `Series` cover load, `GenerateCoverBitmap`, and the user-icon picker all stream from disk with `FileOptions.SequentialScan` and decode to width, removing the original full-size bitmap allocation and `CreateScaledBitmap` copy.
- `UserService` JSON loads (`LoadUserDataAsync`, repair path, upload path) read with async `FileStream` + `JsonNode.ParseAsync` instead of `File.ReadAllTextAsync` → string parse, avoiding the intermediate string allocation.
- `FindCurrentThemeIndex` replaced with a plain indexed loop (no LINQ projection / anonymous type).
- `ExtensionMethods.NormalizeQuotes` and `RemoveInPlaceCharArray` switched to `SearchValues<char>` for the fast-reject scan and a `stackalloc` / `ArrayPool<char>` destination buffer.
- `FilterChipViewModel` uses `Enum.GetNames<T>()` directly instead of `Enum.GetValues<T>().Select(e => e.ToString())`.
- `CollectionStatsViewModel` genre-label arrays built via a small `ExtractKeys` helper instead of LINQ.
- `GlassmorphismService` lifts the per-call `WindowTransparencyLevel` arrays into static readonly fields.
- `DiscordRP` caches the static `Assets` instance and the buttons array, only rebuilding the array when the buttons list is actually dirty.
- `SeriesCardDisplay` moves the `BitmapCache` to the inner card border and caches the resolved `MainWindowViewModel` / `IUserService` across instances, avoiding repeated DI lookups during list rendering.
- `CloneBitmap` now uses the shared `RecyclableMemoryStreamManager` instead of a fresh `MemoryStream`.

### Docs
- Adds the 2.2.2 changelog entry covering the user-visible fixes above plus the Avalonia framework bump.

## Package Bumps

| Package | From | To |
|---|---|---|
| Avalonia.Controls.ColorPicker | 12.0.1 | 12.0.3 |
| Avalonia.Desktop | 12.0.1 | 12.0.3 |
| Avalonia.Themes.Fluent | 12.0.1 | 12.0.3 |
| Avalonia.Headless.NUnit | 12.0.1 | 12.0.3 |
| Avalonia.Diagnostics | 11.3.14 | 11.3.15 |
| NLog | 6.1.2 | 6.1.3 |
| Microsoft.Extensions.Http | 10.0.7 | 10.0.8 |
| System.Drawing.Common | 10.0.7 | 10.0.8 |
| Microsoft.NET.Test.Sdk | 18.4.0 | 18.5.1 |
| NUnit | 4.5.1 | 4.6.0 |
| NUnit.Analyzers | 4.12.0 | 4.13.0 |
| Microsoft.Windows.SDK.BuildTools | 10.0.28000.1721 | 10.0.28000.1839 |

## Test Plan
- [ ] Change the Card Border color in the theme picker and confirm the swatch updates live without restart.
- [ ] Paste a very long cover image URL into Edit Series and confirm the window width does not change.
- [ ] In Price Analysis, bulk-clear and reselect websites; confirm no crash and the tooltip reflects the current selection.
- [ ] Load a user with a high-resolution custom icon and confirm it displays correctly with reduced memory footprint.

## Notes
- The `SeriesCardDisplay` static DI caches assume `App.ServiceProvider` is a singleton process-wide — true in this app, but worth knowing if the bootstrap ever changes.
- `FindCurrentThemeIndex` now uses ordinal string comparison; prior behavior was the default `string.Equals` (also ordinal), so this should be behavior-preserving.